### PR TITLE
Statement typecast added to ProvConstructor

### DIFF
--- a/prov-n/src/main/java/org/openprovenance/prov/notation/ProvConstructor.java
+++ b/prov-n/src/main/java/org/openprovenance/prov/notation/ProvConstructor.java
@@ -135,13 +135,13 @@ public  class ProvConstructor implements TreeConstructor {
         Collection<Entity> es=new LinkedList<Entity>();
         Collection<Agent> ags=new LinkedList<Agent>();
         Collection<Activity> acs=new LinkedList<Activity>();
-        Collection<Object> lks=new LinkedList<Object>();
+        Collection<Statement> lks=new LinkedList<Statement>();
             
         for (Object o: records) {
             if (o instanceof Agent) { ags.add((Agent)o); }
             else if (o instanceof Entity) { es.add((Entity)o); }
             else if (o instanceof Activity) { acs.add((Activity)o); }
-            else lks.add(o);
+            else if (o instanceof Statement) { lks.add((Statement)o); }
         }
         Document c=pFactory.newDocument(      acs,
                                           es,


### PR DESCRIPTION
ProvConstructor was calling newDocument with a Collection of Objects instead of a Collection of Statements. Have amended to match the signature.
