### PR TITLE
Further test fixing

### DIFF
--- a/prov-rdf/src/main/java/org/openprovenance/prov/rdf/RdfConstructor.java
+++ b/prov-rdf/src/main/java/org/openprovenance/prov/rdf/RdfConstructor.java
@@ -615,10 +615,12 @@ public class RdfConstructor implements TreeConstructor {
 		QName qn2 = getQName(id2);
 		QName qn1 = getQName(id1);
 
-		ActivityOrAgentOrEntity e1 = (ActivityOrAgentOrEntity) manager
-				.find(qn1);
-		ActivityOrAgentOrEntity e2 = manager
-				.designate(qn2, ActivityOrAgentOrEntity.class);
+		ActivityOrAgentOrEntity e1 = designateIfNotNull(qn1, ActivityOrAgentOrEntity.class);
+		ActivityOrAgentOrEntity e2 = designateIfNotNull(qn2, ActivityOrAgentOrEntity.class);
+		//(ActivityOrAgentOrEntity) manager
+		//		.find(qn1);
+		//ActivityOrAgentOrEntity e2 = manager
+		//		.designate(qn2, ActivityOrAgentOrEntity.class);
 
 		Influence u = addUnknownInfluence(id, e2, e1, aAttrs, Influence.class);
 

--- a/prov-rdf/src/test/java/org/openprovenance/prov/rdf/ParserTest.java
+++ b/prov-rdf/src/test/java/org/openprovenance/prov/rdf/ParserTest.java
@@ -77,44 +77,6 @@ public class ParserTest extends
 		return true;
 	}
 
-	public void testGeneration7() throws JAXBException
-	{
-		// TODO: fails on comparison on a statement with id=<null> (Originally asserted) and a statement with id =blank node (retrieved from triple store). 
-
-	}
-
-	public void testUsage7() throws JAXBException
-	{
-		// TODO: fails on comparison on a statement with id=<null> (Originally asserted) and a statement with id =blank node (retrieved from triple store). 
-	}
-
-	public void testInvalidation7() throws JAXBException
-	{
-		// TODO: fails on comparison on a statement with id=<null> (Originally asserted) and a statement with id =blank node (retrieved from triple store). 
-	}
-
-	public void testStart10() throws JAXBException
-	{
-		// TODO: fails on comparison on a statement with id=<null> (Originally asserted) and a statement with id =blank node (retrieved from triple store). 
-    	}
-
-	public void testEnd10() throws JAXBException
-	{
-		// TODO: fails on comparison on a statement with id=<null> (Originally asserted) and a statement with id =blank node (retrieved from triple store). 
-	}
-
-	public void testDerivation9() throws JAXBException
-	{
-	        // note, the original assertion was wasDerivedFrom(-,e1) which we could not translate into rdf at all. So, I added types to it.
-		// TODO: fails on comparison on a statement with id=<null> (Originally asserted) and a statement with id =blank node (retrieved from triple store). 
-	}
-
-	public void testDerivation10() throws JAXBException
-	{
-		// TODO: fails on comparison on a statement with id=<null> (Originally asserted) and a statement with id =blank node (retrieved from triple store). 
-		// TODO: Get a wasDerivedFrom as well as a Derivation. <- I don't think it's the case
-	}
-
 	public void testInfluence1() throws JAXBException
 	{
 		// Class cast errors (ActivityOrAgentOrEntity)   Limitation of Elmo, I think this can be fixed by asserting triples without Elmo

--- a/prov-xml/src/test/java/org/openprovenance/prov/xml/RoundTripFromJavaTest.java
+++ b/prov-xml/src/test/java/org/openprovenance/prov/xml/RoundTripFromJavaTest.java
@@ -1139,7 +1139,7 @@ public class RoundTripFromJavaTest extends TestCase {
    	Entity e2=pFactory.newEntity(q("e2"));
    	Statement [] opt=new Statement[] { e2 };
    	
-   	makeDocAndTest(der, "target/derivation9");
+   	makeDocAndTest(der, opt, "target/derivation9");
     }
     
     public void testDerivation10() throws JAXBException {


### PR DESCRIPTION
- Added collision check for WDF and Used. This needs lots of checking (the 'optimize' method, and 'getSignature', primarily. Can we guarantee that this would remove the correct element?
- Added missing opts to derivation9 test.
- Nulls ID on items in influenceMap if they have a blank namespace (i.e. they are BNodes). Unsure if this is 100% reliable - might tweak to store the OpenRDF Value later.
