### PR TITLE
Implicit types

### DIFF
--- a/prov-rdf/src/main/java/org/openprovenance/prov/rdf/Ontology.java
+++ b/prov-rdf/src/main/java/org/openprovenance/prov/rdf/Ontology.java
@@ -10,6 +10,8 @@ import org.openprovenance.prov.xml.NamespacePrefixMapper;
 public class Ontology {
     public Ontology() {
 	initInfluenceTables();
+	initDomainTables();
+	initRangeTables();
     }
 
     public Hashtable<QName, QName> qualifiedInfluenceTable = new Hashtable<QName, QName>();
@@ -19,6 +21,7 @@ public class Ontology {
     public Hashtable<QName, QName> convertTable = new Hashtable<QName, QName>();
 
     public Hashtable<QName, QName> domains = new Hashtable<QName, QName>();
+    public Hashtable<QName, QName> ranges = new Hashtable<QName, QName>();
     
     public static QName newProvQName(String local) {
 	return new QName(NamespacePrefixMapper.PROV_NS, local,
@@ -223,6 +226,49 @@ public class Ontology {
 	convertTable.put(Attribute.PROV_ROLE_QNAME, QNAME_PROVO_hadRole);
     }
     
+    void initRangeTables() {
+    	this.ranges.put(QNAME_PROVO_actedOnBehalfOf, QNAME_PROVO_Agent);
+    	this.ranges.put(QNAME_PROVO_used, QNAME_PROVO_Entity);
+    	this.ranges.put(QNAME_PROVO_wasAssociatedWith, QNAME_PROVO_Agent);
+    	this.ranges.put(QNAME_PROVO_wasAttributedTo, QNAME_PROVO_Agent);
+    	this.ranges.put(QNAME_PROVO_wasDerivedFrom, QNAME_PROVO_Entity);
+    	this.ranges.put(QNAME_PROVO_wasGeneratedBy, QNAME_PROVO_Activity);
+    	this.ranges.put(QNAME_PROVO_wasInformedBy, QNAME_PROVO_Activity);
+    	this.ranges.put(QNAME_PROVO_alternateOf, QNAME_PROVO_Entity);
+    	this.ranges.put(QNAME_PROVO_atLocation, QNAME_PROVO_Location);
+    	this.ranges.put(QNAME_PROVO_generated, QNAME_PROVO_Entity);
+    	this.ranges.put(QNAME_PROVO_hadMember, QNAME_PROVO_Entity);
+    	this.ranges.put(QNAME_PROVO_hadPrimarySource, QNAME_PROVO_Entity);
+    	this.ranges.put(QNAME_PROVO_invalidated, QNAME_PROVO_Entity);
+    	this.ranges.put(QNAME_PROVO_specializationOf, QNAME_PROVO_Entity);
+    	this.ranges.put(QNAME_PROVO_wasEndedBy, QNAME_PROVO_Entity);
+    	this.ranges.put(QNAME_PROVO_wasInvalidatedBy, QNAME_PROVO_Activity);
+    	this.ranges.put(QNAME_PROVO_wasQuotedFrom, QNAME_PROVO_Entity);
+    	this.ranges.put(QNAME_PROVO_wasRevisionOf, QNAME_PROVO_Entity);
+    	this.ranges.put(QNAME_PROVO_wasStartedBy, QNAME_PROVO_Entity);
+    	this.ranges.put(QNAME_PROVO_activity, QNAME_PROVO_Activity);
+    	this.ranges.put(QNAME_PROVO_agent, QNAME_PROVO_Agent);
+    	this.ranges.put(QNAME_PROVO_entity, QNAME_PROVO_Entity);
+    	this.ranges.put(QNAME_PROVO_hadActivity, QNAME_PROVO_Activity);
+    	this.ranges.put(QNAME_PROVO_hadGeneration, QNAME_PROVO_Generation);
+    	this.ranges.put(QNAME_PROVO_hadPlan, QNAME_PROVO_Plan);
+    	this.ranges.put(QNAME_PROVO_hadUsage, QNAME_PROVO_Usage);
+    	this.ranges.put(QNAME_PROVO_qualifiedAssociation, QNAME_PROVO_Association);
+    	this.ranges.put(QNAME_PROVO_qualifiedAttribution, QNAME_PROVO_Attribution);
+    	this.ranges.put(QNAME_PROVO_qualifiedCommunication, QNAME_PROVO_Communication);
+    	this.ranges.put(QNAME_PROVO_qualifiedDelegation, QNAME_PROVO_Delegation);
+    	this.ranges.put(QNAME_PROVO_qualifiedDerivation, QNAME_PROVO_Derivation);
+    	this.ranges.put(QNAME_PROVO_qualifiedEnd, QNAME_PROVO_End);
+    	this.ranges.put(QNAME_PROVO_qualifiedGeneration, QNAME_PROVO_Generation);
+    	this.ranges.put(QNAME_PROVO_qualifiedInfluence, QNAME_PROVO_Influence);
+    	this.ranges.put(QNAME_PROVO_qualifiedInvalidation, QNAME_PROVO_Invalidation);
+    	this.ranges.put(QNAME_PROVO_qualifiedPrimarySource, QNAME_PROVO_PrimarySource);
+    	this.ranges.put(QNAME_PROVO_qualifiedQuotation, QNAME_PROVO_Quotation);
+    	this.ranges.put(QNAME_PROVO_qualifiedRevision, QNAME_PROVO_Revision);
+    	this.ranges.put(QNAME_PROVO_qualifiedStart, QNAME_PROVO_Start);
+    	this.ranges.put(QNAME_PROVO_qualifiedUsage, QNAME_PROVO_Usage);
+    }
+    
     void initDomainTables() {
     	/*
     	 * The domain table maps from predicate to domain. Note that this means
@@ -272,7 +318,7 @@ public class Ontology {
     	this.domains.put(QNAME_PROVO_qualifiedQuotation, QNAME_PROVO_Entity);
     	this.domains.put(QNAME_PROVO_qualifiedRevision, QNAME_PROVO_Entity);
     	
-    	this.domains.put(QNAME_PROVO_EntityInfluence, QNAME_PROVO_EntityInfluence);
+    	this.domains.put(QNAME_PROVO_entity, QNAME_PROVO_EntityInfluence);
     	
     	this.domains.put(QNAME_PROVO_atTime, QNAME_PROVO_InstantaneousEvent);
     	

--- a/prov-rdf/src/main/java/org/openprovenance/prov/rdf/QualifiedCollector.java
+++ b/prov-rdf/src/main/java/org/openprovenance/prov/rdf/QualifiedCollector.java
@@ -58,7 +58,7 @@ public class QualifiedCollector extends RdfCollector {
 			HashMap<QName, List<Statement>> collator = collators.get(contextQ);
 			for (QName qname : collator.keySet())
 			{
-				ProvType[] types = getResourceTypes(contextQ, qname);
+				ProvType[] types = getExplicitTypes(contextQ, qname);
 				for (ProvType type : types)
 				{
 					switch (type)

--- a/prov-rdf/src/test/java/org/openprovenance/prov/rdf/RoundTripFromJavaTest.java
+++ b/prov-rdf/src/test/java/org/openprovenance/prov/rdf/RoundTripFromJavaTest.java
@@ -53,22 +53,11 @@ public class RoundTripFromJavaTest extends
 	@Override
 	public boolean checkTest(String name)
 	{
-		if (name.endsWith("generation6-S" + extension())
-				|| name.endsWith("invalidation6-S" + extension())
-				|| name.endsWith("usage6-S" + extension())
-				|| name.endsWith("start9-S" + extension())
-				|| name.endsWith("end9-S" + extension())
-				|| name.endsWith("attribution5-S" + extension())
-				|| name.endsWith("delegation5-S" + extension())
-				|| name.endsWith("association5-S" + extension())
-				|| name.endsWith("communication4-S" + extension())
-				|| name.endsWith("specialization1-S" + extension())
-				|| name.endsWith("alternate1-S" + extension())
-				|| name.endsWith("mention1-S" + extension())
-				|| name.endsWith("mention2-S" + extension()))
+		if(name.endsWith("mention1"+extension()) || name.endsWith("mention2"+extension()))
 		{
 			return false;
 		}
+		
 		return true;
 	}
 

--- a/prov-xml/src/test/java/org/openprovenance/prov/xml/RoundTripFromJavaTest.java
+++ b/prov-xml/src/test/java/org/openprovenance/prov/xml/RoundTripFromJavaTest.java
@@ -567,9 +567,7 @@ public class RoundTripFromJavaTest extends TestCase {
 							pFactory.newEntityRef(q("e1")),
 							null,
 							null);
-	Entity e1=pFactory.newEntity(q("e1"));
-	Statement [] opt=new Statement[] { e1 };
-	makeDocAndTest(gen, opt , "target/generation1");
+	makeDocAndTest(gen, "target/generation1");
     }
 
 
@@ -579,11 +577,8 @@ public class RoundTripFromJavaTest extends TestCase {
 							pFactory.newEntityRef(q("e1")),
 							null,
 							pFactory.newActivityRef(q("a1")));
-	Entity e1=pFactory.newEntity(q("e1"));
-	Activity a1=pFactory.newActivity(q("a1"));
-	Statement [] opt=new Statement[] { e1, a1 };
 
-	makeDocAndTest(gen, opt, "target/generation2");
+	makeDocAndTest(gen, "target/generation2");
     }
 
 
@@ -594,10 +589,7 @@ public class RoundTripFromJavaTest extends TestCase {
 							"somerole",
 							pFactory.newActivityRef(q("a1")));
         gen.getRole().add("otherRole");
-    	Entity e1=pFactory.newEntity(q("e1"));
-    	Activity a1=pFactory.newActivity(q("a1"));
-    	Statement [] opt=new Statement[] { e1, a1 };
-	makeDocAndTest(gen,opt,"target/generation3");
+	makeDocAndTest(gen,"target/generation3");
     }
 
 
@@ -608,10 +600,7 @@ public class RoundTripFromJavaTest extends TestCase {
                                                         "somerole",
                                                         pFactory.newActivityRef(q("a1")));
         gen.setTime(pFactory.newTimeNow());
-    	Entity e1=pFactory.newEntity(q("e1"));
-    	Activity a1=pFactory.newActivity(q("a1"));
-    	Statement [] opt=new Statement[] { e1, a1 };
-        makeDocAndTest(gen,opt,"target/generation4");
+        makeDocAndTest(gen,"target/generation4");
     }
     
     public void testGeneration5() throws JAXBException  {
@@ -626,10 +615,7 @@ public class RoundTripFromJavaTest extends TestCase {
         addLabels(gen);
         addFurtherAttributes(gen);
 
-    	Entity e1=pFactory.newEntity(q("e1"));
-    	Activity a1=pFactory.newActivity(q("a1"));
-    	Statement [] opt=new Statement[] { e1, a1 };
-        makeDocAndTest(gen,opt,"target/generation5");
+        makeDocAndTest(gen,"target/generation5");
     }
     
     
@@ -639,10 +625,7 @@ public class RoundTripFromJavaTest extends TestCase {
   							pFactory.newEntityRef(q("e1")),
   							null,
   							pFactory.newActivityRef(q("a1")));
-	Entity e1=pFactory.newEntity(q("e1"));
-	Activity a1=pFactory.newActivity(q("a1"));
-	Statement [] opt=new Statement[] { e1, a1 };
-  	makeDocAndTest(gen,opt,"target/generation6");
+  	makeDocAndTest(gen,"target/generation6");
       }
 
     public void testGeneration7() throws JAXBException  {
@@ -657,10 +640,7 @@ public class RoundTripFromJavaTest extends TestCase {
         addLabels(gen);
         addFurtherAttributes(gen);
 
-    	Entity e1=pFactory.newEntity(q("e1"));
-    	Activity a1=pFactory.newActivity(q("a1"));
-    	Statement [] opt=new Statement[] { e1, a1 };
-        makeDocAndTest(gen,opt,"target/generation7");
+        makeDocAndTest(gen,"target/generation7");
     }
     
     //////////////////////////////////
@@ -671,9 +651,7 @@ public class RoundTripFromJavaTest extends TestCase {
                                     null,
                                     null,
                                     pFactory.newEntityRef(q("e1")));
-    	Entity e1=pFactory.newEntity(q("e1"));
-    	Statement [] opt=new Statement[] { e1 };
-        makeDocAndTest(use,opt,"target/usage1");
+        makeDocAndTest(use,"target/usage1");
     }
 
     public void testUsage2() throws JAXBException  {
@@ -683,10 +661,7 @@ public class RoundTripFromJavaTest extends TestCase {
                                     null,
                                     pFactory.newEntityRef(q("e1")));
         
-    	Entity e1=pFactory.newEntity(q("e1"));
-    	Activity a1=pFactory.newActivity(q("a1"));
-    	Statement [] opt=new Statement[] { e1, a1 };
-        makeDocAndTest(use,opt,"target/usage2");
+        makeDocAndTest(use,"target/usage2");
     }
 
     public void testUsage3() throws JAXBException  {
@@ -697,10 +672,7 @@ public class RoundTripFromJavaTest extends TestCase {
                                     pFactory.newEntityRef(q("e1")));
         use.getRole().add("otherRole");
         
-    	Entity e1=pFactory.newEntity(q("e1"));
-    	Activity a1=pFactory.newActivity(q("a1"));
-    	Statement [] opt=new Statement[] { e1, a1 };
-        makeDocAndTest(use,opt,"target/usage3");
+        makeDocAndTest(use,"target/usage3");
     }
     
     public void testUsage4() throws JAXBException  {
@@ -711,10 +683,7 @@ public class RoundTripFromJavaTest extends TestCase {
                                     pFactory.newEntityRef(q("e1")));
         use.setTime(pFactory.newTimeNow());
 
-    	Entity e1=pFactory.newEntity(q("e1"));
-    	Activity a1=pFactory.newActivity(q("a1"));
-    	Statement [] opt=new Statement[] { e1, a1 };
-        makeDocAndTest(use,opt,"target/usage4");
+        makeDocAndTest(use,"target/usage4");
     }
 
     public void testUsage5() throws JAXBException  {
@@ -729,10 +698,7 @@ public class RoundTripFromJavaTest extends TestCase {
         addLabels(use);
         addFurtherAttributes(use);
         
-    	Entity e1=pFactory.newEntity(q("e1"));
-    	Activity a1=pFactory.newActivity(q("a1"));
-    	Statement [] opt=new Statement[] { e1, a1 };
-        makeDocAndTest(use,opt,"target/usage5");
+        makeDocAndTest(use,"target/usage5");
     }
 
     public void testUsage6() throws JAXBException  {
@@ -742,10 +708,7 @@ public class RoundTripFromJavaTest extends TestCase {
                                     null,
                                     pFactory.newEntityRef(q("e1")));
 
-    	Entity e1=pFactory.newEntity(q("e1"));
-    	Activity a1=pFactory.newActivity(q("a1"));
-    	Statement [] opt=new Statement[] { e1, a1 };
-        makeDocAndTest(use,opt,"target/usage6");
+        makeDocAndTest(use,"target/usage6");
     }
 
     public void testUsage7() throws JAXBException  {
@@ -760,10 +723,7 @@ public class RoundTripFromJavaTest extends TestCase {
         addLabels(use);
         addFurtherAttributes(use);
         
-    	Entity e1=pFactory.newEntity(q("e1"));
-    	Activity a1=pFactory.newActivity(q("a1"));
-    	Statement [] opt=new Statement[] { e1, a1 };
-        makeDocAndTest(use,opt,"target/usage7");
+        makeDocAndTest(use,"target/usage7");
     }
     
     // //////////////////////////////////////////////
@@ -773,9 +733,7 @@ public class RoundTripFromJavaTest extends TestCase {
 	WasInvalidatedBy inv = pFactory.newWasInvalidatedBy(q("inv1"),
 							    pFactory.newEntityRef(q("e1")),
 							    null);
-	Entity e1=pFactory.newEntity(q("e1"));
-	Statement [] opt=new Statement[] { e1 };
-	makeDocAndTest(inv, opt, "target/invalidation1");
+	makeDocAndTest(inv,  "target/invalidation1");
     }
 
     public void testInvalidation2() throws JAXBException {
@@ -783,10 +741,7 @@ public class RoundTripFromJavaTest extends TestCase {
 	WasInvalidatedBy inv = pFactory.newWasInvalidatedBy(q("inv2"),
 							    pFactory.newEntityRef(q("e1")),
 							    pFactory.newActivityRef(q("a1")));
-	Entity e1=pFactory.newEntity(q("e1"));
-	Activity a1=pFactory.newActivity(q("a1"));
-	Statement [] opt=new Statement[] { e1, a1 };
-	makeDocAndTest(inv, opt, "target/invalidation2");
+	makeDocAndTest(inv, "target/invalidation2");
     }
 
     public void testInvalidation3() throws JAXBException {
@@ -796,10 +751,7 @@ public class RoundTripFromJavaTest extends TestCase {
 							    pFactory.newActivityRef(q("a1")));
 	inv.getRole().add("someRole");
 	inv.getRole().add("otherRole");
-	Entity e1=pFactory.newEntity(q("e1"));
-	Activity a1=pFactory.newActivity(q("a1"));
-	Statement [] opt=new Statement[] { e1, a1 };
-	makeDocAndTest(inv, opt, "target/invalidation3");
+	makeDocAndTest(inv,  "target/invalidation3");
     }
 
     public void testInvalidation4() throws JAXBException {
@@ -809,10 +761,7 @@ public class RoundTripFromJavaTest extends TestCase {
 							    pFactory.newActivityRef(q("a1")));
 	inv.getRole().add("someRole");
 	inv.setTime(pFactory.newTimeNow());
-	Entity e1=pFactory.newEntity(q("e1"));
-	Activity a1=pFactory.newActivity(q("a1"));
-	Statement [] opt=new Statement[] { e1, a1 };
-	makeDocAndTest(inv, opt, "target/invalidation4");
+	makeDocAndTest(inv,  "target/invalidation4");
     }
 
     public void testInvalidation5() throws JAXBException {
@@ -828,10 +777,7 @@ public class RoundTripFromJavaTest extends TestCase {
 	addLabels(inv);
 	addFurtherAttributes(inv);
 
-	Entity e1=pFactory.newEntity(q("e1"));
-	Activity a1=pFactory.newActivity(q("a1"));
-	Statement [] opt=new Statement[] { e1, a1 };
-	makeDocAndTest(inv, opt, "target/invalidation5");
+	makeDocAndTest(inv,  "target/invalidation5");
     }
 
     public void testInvalidation6() throws JAXBException {
@@ -839,10 +785,7 @@ public class RoundTripFromJavaTest extends TestCase {
 	WasInvalidatedBy inv = pFactory.newWasInvalidatedBy((QName) null,
 							    pFactory.newEntityRef(q("e1")),
 							    pFactory.newActivityRef(q("a1")));
-	Entity e1=pFactory.newEntity(q("e1"));
-	Activity a1=pFactory.newActivity(q("a1"));
-	Statement [] opt=new Statement[] { e1, a1 };
-	makeDocAndTest(inv, opt, "target/invalidation6");
+	makeDocAndTest(inv,  "target/invalidation6");
     }
 
     public void testInvalidation7() throws JAXBException {
@@ -857,10 +800,7 @@ public class RoundTripFromJavaTest extends TestCase {
 	addLabels(inv);
 	addFurtherAttributes(inv);
 
-	Entity e1=pFactory.newEntity(q("e1"));
-	Activity a1=pFactory.newActivity(q("a1"));
-	Statement [] opt=new Statement[] { e1, a1 };
-	makeDocAndTest(inv, opt, "target/invalidation7");
+	makeDocAndTest(inv, "target/invalidation7");
     }
     
 //////////////////////////////////
@@ -871,9 +811,7 @@ public class RoundTripFromJavaTest extends TestCase {
 						      null,
 						      pFactory.newEntityRef(q("e1")));
 	
-	Entity e1=pFactory.newEntity(q("e1"));
-	Statement [] opt=new Statement[] { e1 };
-	makeDocAndTest(start, opt, "target/start1");
+	makeDocAndTest(start, "target/start1");
     }
 
     public void testStart2() throws JAXBException {
@@ -881,10 +819,8 @@ public class RoundTripFromJavaTest extends TestCase {
 	WasStartedBy start = pFactory.newWasStartedBy(q("start2"),
 						      pFactory.newActivityRef(q("a1")),
 						      pFactory.newEntityRef(q("e1")));
-	Entity e1=pFactory.newEntity(q("e1"));
-	Activity a1=pFactory.newActivity(q("a1"));
-	Statement [] opt=new Statement[] { e1, a1 };
-	makeDocAndTest(start, opt, "target/start2");
+	
+	makeDocAndTest(start, "target/start2");
     }
 
     public void testStart3() throws JAXBException {
@@ -892,9 +828,8 @@ public class RoundTripFromJavaTest extends TestCase {
 	WasStartedBy start = pFactory.newWasStartedBy(q("start3"),
 						      pFactory.newActivityRef(q("a1")),
 						      null);
-	Activity a1=pFactory.newActivity(q("a1"));
-	Statement [] opt=new Statement[] { a1 };
-	makeDocAndTest(start, opt, "target/start3");
+	
+	makeDocAndTest(start, "target/start3");
     }
 
     public void testStart4() throws JAXBException {
@@ -904,10 +839,7 @@ public class RoundTripFromJavaTest extends TestCase {
 						      pFactory.newEntityRef(q("e1")));
 	start.setStarter(pFactory.newActivityRef(q("a2")));
 	
-	Entity e1=pFactory.newEntity(q("e1"));
-	Activity a2=pFactory.newActivity(q("a2"));
-	Statement [] opt=new Statement[] { e1, a2 };
-	makeDocAndTest(start, opt, "target/start4");
+	makeDocAndTest(start, "target/start4");
     }
 
     public void testStart5() throws JAXBException {
@@ -917,11 +849,7 @@ public class RoundTripFromJavaTest extends TestCase {
 						      pFactory.newEntityRef(q("e1")));
 	start.setStarter(pFactory.newActivityRef(q("a2")));
 	
-	Entity e1=pFactory.newEntity(q("e1"));
-	Activity a1=pFactory.newActivity(q("a1"));
-	Activity a2=pFactory.newActivity(q("a2"));
-	Statement [] opt=new Statement[] { e1, a1, a2 };
-	makeDocAndTest(start, opt, "target/start5");
+	makeDocAndTest(start, "target/start5");
     }
 
     public void testStart6() throws JAXBException {
@@ -931,10 +859,7 @@ public class RoundTripFromJavaTest extends TestCase {
 						      null);
 	start.setStarter(pFactory.newActivityRef(q("a2")));
 	
-	Activity a1=pFactory.newActivity(q("a1"));
-	Activity a2=pFactory.newActivity(q("a2"));
-	Statement [] opt=new Statement[] { a1, a2 };
-	makeDocAndTest(start, opt, "target/start6");
+	makeDocAndTest(start, "target/start6");
     }
 
     
@@ -946,10 +871,7 @@ public class RoundTripFromJavaTest extends TestCase {
    	start.setStarter(pFactory.newActivityRef(q("a2")));
    	start.setTime(pFactory.newTimeNow());
 
-	Activity a1=pFactory.newActivity(q("a1"));
-	Activity a2=pFactory.newActivity(q("a2"));
-	Statement [] opt=new Statement[] { a1, a2 };
-   	makeDocAndTest(start, opt, "target/start7");
+   	makeDocAndTest(start, "target/start7");
     }
     
     public void testStart8() throws JAXBException {
@@ -966,10 +888,7 @@ public class RoundTripFromJavaTest extends TestCase {
 	addLabels(start);
 	addFurtherAttributes(start);
 
-	Activity a1=pFactory.newActivity(q("a1"));
-	Activity a2=pFactory.newActivity(q("a2"));
-	Statement [] opt=new Statement[] { a1, a2 };
-   	makeDocAndTest(start, opt, "target/start8");
+   	makeDocAndTest(start, "target/start8");
     }
     
     public void testStart9() throws JAXBException {
@@ -978,10 +897,7 @@ public class RoundTripFromJavaTest extends TestCase {
    						      pFactory.newActivityRef(q("a1")),
    						      pFactory.newEntityRef(q("e1")));
    	
-	Entity e1=pFactory.newEntity(q("e1"));
-	Activity a1=pFactory.newActivity(q("a1"));
-	Statement [] opt=new Statement[] { e1, a1 };
-   	makeDocAndTest(start, opt, "target/start9");
+   	makeDocAndTest(start, "target/start9");
        }
     
     public void testStart10() throws JAXBException {
@@ -998,10 +914,7 @@ public class RoundTripFromJavaTest extends TestCase {
 	addLabels(start);
 	addFurtherAttributes(start);
 
-	Activity a1=pFactory.newActivity(q("a1"));
-	Activity a2=pFactory.newActivity(q("a2"));
-	Statement [] opt=new Statement[] { a1, a2 };
-   	makeDocAndTest(start, opt, "target/start10");
+   	makeDocAndTest(start, "target/start10");
     }
     
     // ////////////////////////////////
@@ -1010,9 +923,8 @@ public class RoundTripFromJavaTest extends TestCase {
 	setNamespaces();
 	WasEndedBy end = pFactory.newWasEndedBy(q("end1"), null,
 						pFactory.newEntityRef(q("e1")));
-	Entity e1=pFactory.newEntity(q("e1"));
-	Statement [] opt=new Statement[] { e1 };
-	makeDocAndTest(end, opt, "target/end1");
+	
+	makeDocAndTest(end, "target/end1");
     }
 
     public void testEnd2() throws JAXBException {
@@ -1021,11 +933,7 @@ public class RoundTripFromJavaTest extends TestCase {
 						pFactory.newActivityRef(q("a1")),
 						pFactory.newEntityRef(q("e1")));
 
-	Activity a1=pFactory.newActivity(q("a1"));
-	Entity e1=pFactory.newEntity(q("e1"));
-	Statement [] opt=new Statement[] { a1, e1 };
-	
-	makeDocAndTest(end, opt, "target/end2");
+	makeDocAndTest(end, "target/end2");
     }
 
     public void testEnd3() throws JAXBException {
@@ -1033,9 +941,8 @@ public class RoundTripFromJavaTest extends TestCase {
 	WasEndedBy end = pFactory.newWasEndedBy(q("end3"),
 						pFactory.newActivityRef(q("a1")),
 						null);
-	Activity a1=pFactory.newActivity(q("a1"));
-	Statement [] opt=new Statement[] { a1 };
-	makeDocAndTest(end, opt, "target/end3");
+	
+	makeDocAndTest(end, "target/end3");
     }
 
     public void testEnd4() throws JAXBException {
@@ -1044,10 +951,7 @@ public class RoundTripFromJavaTest extends TestCase {
 						pFactory.newEntityRef(q("e1")));
 	end.setEnder(pFactory.newActivityRef(q("a2")));
 	
-	Activity a2=pFactory.newActivity(q("a2"));
-	Entity e1=pFactory.newEntity(q("e1"));
-	Statement [] opt=new Statement[] { a2, e1 };
-	makeDocAndTest(end, opt, "target/end4");
+	makeDocAndTest(end, "target/end4");
     }
 
     public void testEnd5() throws JAXBException {
@@ -1057,11 +961,7 @@ public class RoundTripFromJavaTest extends TestCase {
 						pFactory.newEntityRef(q("e1")));
 	end.setEnder(pFactory.newActivityRef(q("a2")));
 
-	Activity a1=pFactory.newActivity(q("a1"));
-	Activity a2=pFactory.newActivity(q("a2"));
-	Entity e1=pFactory.newEntity(q("e1"));
-	Statement [] opt=new Statement[] { a2, e1, a1 };
-	makeDocAndTest(end, opt, "target/end5");
+	makeDocAndTest(end, "target/end5");
     }
 
     public void testEnd6() throws JAXBException {
@@ -1071,10 +971,7 @@ public class RoundTripFromJavaTest extends TestCase {
 						null);
 	end.setEnder(pFactory.newActivityRef(q("a2")));
 	
-	Activity a1=pFactory.newActivity(q("a1"));
-	Activity a2=pFactory.newActivity(q("a2"));
-	Statement [] opt=new Statement[] { a2, a1 };
-	makeDocAndTest(end, opt, "target/end6");
+	makeDocAndTest(end, "target/end6");
     }
 
     public void testEnd7() throws JAXBException {
@@ -1085,10 +982,7 @@ public class RoundTripFromJavaTest extends TestCase {
 	end.setEnder(pFactory.newActivityRef(q("a2")));
 	end.setTime(pFactory.newTimeNow());
 	
-	Activity a1=pFactory.newActivity(q("a1"));
-	Activity a2=pFactory.newActivity(q("a2"));
-	Statement [] opt=new Statement[] { a2, a1 };
-	makeDocAndTest(end, opt, "target/end7");
+	makeDocAndTest(end, "target/end7");
     }
 
     public void testEnd8() throws JAXBException {
@@ -1105,10 +999,7 @@ public class RoundTripFromJavaTest extends TestCase {
 	addLabels(end);
 	addFurtherAttributes(end);
 
-	Activity a1=pFactory.newActivity(q("a1"));
-	Activity a2=pFactory.newActivity(q("a2"));
-	Statement [] opt=new Statement[] { a2, a1 };
-	makeDocAndTest(end, opt, "target/end8");
+	makeDocAndTest(end, "target/end8");
     }
 
     public void testEnd9() throws JAXBException {
@@ -1117,10 +1008,7 @@ public class RoundTripFromJavaTest extends TestCase {
 						pFactory.newActivityRef(q("a1")),
 						pFactory.newEntityRef(q("e1")));
 	
-	Activity a1=pFactory.newActivity(q("a1"));
-	Entity e1=pFactory.newEntity(q("e1"));
-	Statement [] opt=new Statement[] { e1, a1 };
-	makeDocAndTest(end, opt, "target/end9");
+	makeDocAndTest(end, "target/end9");
     }
 
     public void testEnd10() throws JAXBException {
@@ -1137,11 +1025,7 @@ public class RoundTripFromJavaTest extends TestCase {
 	addLabels(end);
 	addFurtherAttributes(end);
 
-
-	Activity a1=pFactory.newActivity(q("a1"));
-	Activity a2=pFactory.newActivity(q("a2"));
-	Statement [] opt=new Statement[] { a2, a1 };
-	makeDocAndTest(end, opt, "target/end10");
+	makeDocAndTest(end, "target/end10");
     }
     
     
@@ -1152,9 +1036,7 @@ public class RoundTripFromJavaTest extends TestCase {
 	WasDerivedFrom der = pFactory.newWasDerivedFrom(q("der1"), 
 	                                                null,
 	                                                pFactory.newEntityRef(q("e1")));
-	Entity e1=pFactory.newEntity(q("e1"));
-	Statement [] opt=new Statement[] { e1 };
-	makeDocAndTest(der, opt, "target/derivation1");
+	makeDocAndTest(der, "target/derivation1");
     }
 
     public void testDerivation2() throws JAXBException {
@@ -1162,9 +1044,7 @@ public class RoundTripFromJavaTest extends TestCase {
    	WasDerivedFrom der = pFactory.newWasDerivedFrom(q("der2"), 
    	                                                pFactory.newEntityRef(q("e2")),
    	                                                null);
-   	Entity e2=pFactory.newEntity(q("e2"));
-   	Statement [] opt=new Statement[] { e2 };
-   	makeDocAndTest(der, opt, "target/derivation2");
+   	makeDocAndTest(der, "target/derivation2");
     }
     
     public void testDerivation3() throws JAXBException {
@@ -1172,10 +1052,7 @@ public class RoundTripFromJavaTest extends TestCase {
    	WasDerivedFrom der = pFactory.newWasDerivedFrom(q("der3"), 
    	                                                pFactory.newEntityRef(q("e2")),
    	                                                pFactory.newEntityRef(q("e1")));   	
-   	Entity e1=pFactory.newEntity(q("e1"));
-   	Entity e2=pFactory.newEntity(q("e2"));
-   	Statement [] opt=new Statement[] { e1, e2 };
-   	makeDocAndTest(der, opt, "target/derivation3");
+   	makeDocAndTest(der, "target/derivation3");
     }
 
     public void testDerivation4() throws JAXBException {
@@ -1184,10 +1061,7 @@ public class RoundTripFromJavaTest extends TestCase {
    	                                                pFactory.newEntityRef(q("e2")),
    	                                                pFactory.newEntityRef(q("e1")));
    	addLabel(der);
-   	Entity e1=pFactory.newEntity(q("e1"));
-   	Entity e2=pFactory.newEntity(q("e2"));
-   	Statement [] opt=new Statement[] { e1, e2 };
-   	makeDocAndTest(der, opt, "target/derivation4");
+   	makeDocAndTest(der, "target/derivation4");
     }
     
     public void testDerivation5() throws JAXBException {
@@ -1196,11 +1070,7 @@ public class RoundTripFromJavaTest extends TestCase {
    	                                                pFactory.newEntityRef(q("e2")),
    	                                                pFactory.newEntityRef(q("e1")));
    	der.setActivity(pFactory.newActivityRef(q("a")));
-   	Entity e1=pFactory.newEntity(q("e1"));
-   	Entity e2=pFactory.newEntity(q("e2"));
-	Activity a=pFactory.newActivity(q("a"));
-   	Statement [] opt=new Statement[] { e1, e2, a };
-   	makeDocAndTest(der, opt, "target/derivation5");
+   	makeDocAndTest(der, "target/derivation5");
     }
     
     
@@ -1211,14 +1081,7 @@ public class RoundTripFromJavaTest extends TestCase {
    	                                                pFactory.newEntityRef(q("e1")));
    	der.setActivity(pFactory.newActivityRef(q("a")));
    	der.setUsage(pFactory.newUsageRef(q("u")));
-   	
-   	Entity e1=pFactory.newEntity(q("e1"));
-   	Entity e2=pFactory.newEntity(q("e2"));
-	Activity a=pFactory.newActivity(q("a"));
-	Used u=pFactory.newUsed(q("u"));
-   	Statement [] opt=new Statement[] { e1, e2, a, u };
-   	
-   	makeDocAndTest(der, opt, "target/derivation6");
+   	makeDocAndTest(der, "target/derivation6");
     }
     
     public void testDerivation7() throws JAXBException {
@@ -1230,15 +1093,7 @@ public class RoundTripFromJavaTest extends TestCase {
    	der.setUsage(pFactory.newUsageRef(q("u")));
    	der.setGeneration(pFactory.newGenerationRef(q("g")));
    	
-
-   	Entity e1=pFactory.newEntity(q("e1"));
-   	Entity e2=pFactory.newEntity(q("e2"));
-	Activity a=pFactory.newActivity(q("a"));
-	Used u=pFactory.newUsed(q("u"));
-	WasGeneratedBy g=pFactory.newWasGeneratedBy(q("g"));
-   	Statement [] opt=new Statement[] { e1, e2, a, u, g };
-   	
-   	makeDocAndTest(der, opt, "target/derivation7");
+   	makeDocAndTest(der, "target/derivation7");
     }
     
     
@@ -1252,12 +1107,7 @@ public class RoundTripFromJavaTest extends TestCase {
    	addTypes(der);
    	addFurtherAttributes(der);
    	
-
-   	Entity e1=pFactory.newEntity(q("e1"));
-   	Entity e2=pFactory.newEntity(q("e2"));
-   	Statement [] opt=new Statement[] { e1, e2 };
-   	
-   	makeDocAndTest(der, opt, "target/derivation8");
+   	makeDocAndTest(der, "target/derivation8");
     }
     
     public void testDerivation9() throws JAXBException {
@@ -1266,10 +1116,7 @@ public class RoundTripFromJavaTest extends TestCase {
    	                                                pFactory.newEntityRef(q("e2")),
    	                                                null);
    	addTypes(der);
-   	Entity e2=pFactory.newEntity(q("e2"));
-   	Statement [] opt=new Statement[] { e2 };
-   	
-   	makeDocAndTest(der, opt, "target/derivation9");
+   	makeDocAndTest(der, "target/derivation9");
     }
     
     public void testDerivation10() throws JAXBException {
@@ -1280,15 +1127,7 @@ public class RoundTripFromJavaTest extends TestCase {
         der.setActivity(pFactory.newActivityRef(q("a")));
         der.setUsage(pFactory.newUsageRef(q("u")));
         der.setGeneration(pFactory.newGenerationRef(q("g")));
-
-       	Entity e1=pFactory.newEntity(q("e1"));
-       	Entity e2=pFactory.newEntity(q("e2"));
-    	Activity a=pFactory.newActivity(q("a"));
-    	Used u=pFactory.newUsed(q("u"));
-    	WasGeneratedBy g=pFactory.newWasGeneratedBy(q("g"));
-       	Statement [] opt=new Statement[] { e1, e2, a, u, g };
-       	
-        makeDocAndTest(der, opt, "target/derivation10");
+        makeDocAndTest(der, "target/derivation10");
     }
     
     public void testDerivation11() throws JAXBException {
@@ -1300,15 +1139,7 @@ public class RoundTripFromJavaTest extends TestCase {
         der.setUsage(pFactory.newUsageRef(q("u")));
         der.setGeneration(pFactory.newGenerationRef(q("g")));
         pFactory.addRevisionType(der);
-
-       	Entity e1=pFactory.newEntity(q("e1"));
-       	Entity e2=pFactory.newEntity(q("e2"));
-    	Activity a=pFactory.newActivity(q("a"));
-    	Used u=pFactory.newUsed(q("u"));
-    	WasGeneratedBy g=pFactory.newWasGeneratedBy(q("g"));
-       	Statement [] opt=new Statement[] { e1, e2, a, u, g };
-       	
-        makeDocAndTest(der, opt, "target/derivation11");
+        makeDocAndTest(der, "target/derivation11");
     }
 
     public void testDerivation12() throws JAXBException {
@@ -1320,15 +1151,7 @@ public class RoundTripFromJavaTest extends TestCase {
         der.setUsage(pFactory.newUsageRef(q("u")));
         der.setGeneration(pFactory.newGenerationRef(q("g")));
         pFactory.addQuotationType(der);
-
-       	Entity e1=pFactory.newEntity(q("e1"));
-       	Entity e2=pFactory.newEntity(q("e2"));
-    	Activity a=pFactory.newActivity(q("a"));
-    	Used u=pFactory.newUsed(q("u"));
-    	WasGeneratedBy g=pFactory.newWasGeneratedBy(q("g"));
-       	Statement [] opt=new Statement[] { e1, e2, a, u, g };
-       	
-        makeDocAndTest(der, opt, "target/derivation12");
+        makeDocAndTest(der, "target/derivation12");
     }
 
     public void testDerivation13() throws JAXBException {
@@ -1340,15 +1163,7 @@ public class RoundTripFromJavaTest extends TestCase {
         der.setUsage(pFactory.newUsageRef(q("u")));
         der.setGeneration(pFactory.newGenerationRef(q("g")));
         pFactory.addPrimarySourceType(der);
-        
-       	Entity e1=pFactory.newEntity(q("e1"));
-       	Entity e2=pFactory.newEntity(q("e2"));
-    	Activity a=pFactory.newActivity(q("a"));
-    	Used u=pFactory.newUsed(q("u"));
-    	WasGeneratedBy g=pFactory.newWasGeneratedBy(q("g"));
-       	Statement [] opt=new Statement[] { e1, e2, a, u, g };
-       	
-        makeDocAndTest(der, opt, "target/derivation13");
+        makeDocAndTest(der, "target/derivation13");
     }
     
     // ////////////////////////////////
@@ -1358,9 +1173,7 @@ public class RoundTripFromJavaTest extends TestCase {
         WasAssociatedWith assoc = pFactory.newWasAssociatedWith(q("assoc1"), 
                                                                 pFactory.newActivityRef(q("a1")),
                                                                 null);
-    	Activity a1=pFactory.newActivity(q("a1"));
-    	Statement [] opt=new Statement[] { a1 };
-        makeDocAndTest(assoc, opt, "target/association1");
+        makeDocAndTest(assoc, "target/association1");
     }
 
     public void testAssociation2() throws JAXBException {
@@ -1368,9 +1181,7 @@ public class RoundTripFromJavaTest extends TestCase {
         WasAssociatedWith assoc = pFactory.newWasAssociatedWith(q("assoc2"), 
                                                                 null,
                                                                 pFactory.newAgentRef(q("ag1")));
-        Agent ag1=pFactory.newAgent(q("ag1"));
-        Statement [] opt = new Statement[] { ag1 };
-        makeDocAndTest(assoc, opt, "target/association2");
+        makeDocAndTest(assoc, "target/association2");
     }
 
     public void testAssociation3() throws JAXBException {
@@ -1378,10 +1189,7 @@ public class RoundTripFromJavaTest extends TestCase {
         WasAssociatedWith assoc = pFactory.newWasAssociatedWith(q("assoc3"), 
                                                                 pFactory.newActivityRef(q("a1")),
                                                                 pFactory.newAgentRef(q("ag1")));
-        Agent ag1=pFactory.newAgent(q("ag1"));
-        Activity a1=pFactory.newActivity(q("a1"));
-        Statement [] opt = new Statement[] { ag1, a1 };
-        makeDocAndTest(assoc, opt, "target/association3");
+        makeDocAndTest(assoc, "target/association3");
     }
 
 
@@ -1391,12 +1199,7 @@ public class RoundTripFromJavaTest extends TestCase {
                                                                 pFactory.newActivityRef(q("a1")),
                                                                 pFactory.newAgentRef(q("ag1")));
         assoc.setPlan(pFactory.newEntityRef(q("plan1")));
-        Agent ag1=pFactory.newAgent(q("ag1"));
-        Activity a1=pFactory.newActivity(q("a1"));
-        Entity plan1=pFactory.newEntity(q("plan1"));
-        pFactory.addType(plan1, pFactory.newQName("prov:Plan"));
-        Statement [] opt = new Statement[] { ag1, a1, plan1 };
-        makeDocAndTest(assoc, opt, "target/association4");
+        makeDocAndTest(assoc, "target/association4");
     }
 
     
@@ -1405,10 +1208,7 @@ public class RoundTripFromJavaTest extends TestCase {
         WasAssociatedWith assoc = pFactory.newWasAssociatedWith((QName)null, 
                                                                 pFactory.newActivityRef(q("a1")),
                                                                 pFactory.newAgentRef(q("ag1")));
-        Agent ag1=pFactory.newAgent(q("ag1"));
-        Activity a1=pFactory.newActivity(q("a1"));
-        Statement [] opt = new Statement[] { ag1, a1 };
-        makeDocAndTest(assoc, opt, "target/association5");
+        makeDocAndTest(assoc, "target/association5");
     }
     
     
@@ -1420,14 +1220,7 @@ public class RoundTripFromJavaTest extends TestCase {
                                                                 pFactory.newAgentRef(q("ag1")));
         assoc.setPlan(pFactory.newEntityRef(q("plan1")));
         addLabels(assoc);
-        
-        Agent ag1=pFactory.newAgent(q("ag1"));
-        Activity a1=pFactory.newActivity(q("a1"));
-        Entity plan1=pFactory.newEntity(q("plan1"));
-        pFactory.addType(plan1, pFactory.newQName("prov:Plan"));
-        Statement [] opt = new Statement[] { ag1, a1, plan1 };
-        
-        makeDocAndTest(assoc, opt, "target/association6");
+        makeDocAndTest(assoc, "target/association6");
     }
 
     public void testAssociation7() throws JAXBException {
@@ -1438,14 +1231,7 @@ public class RoundTripFromJavaTest extends TestCase {
         assoc.setPlan(pFactory.newEntityRef(q("plan1")));
         addLabels(assoc);
         addTypes(assoc);        
-        
-        Agent ag1=pFactory.newAgent(q("ag1"));
-        Activity a1=pFactory.newActivity(q("a1"));
-        Entity plan1=pFactory.newEntity(q("plan1"));
-        pFactory.addType(plan1, pFactory.newQName("prov:Plan"));
-        Statement [] opt = new Statement[] { ag1, a1, plan1 };
-        
-        makeDocAndTest(assoc, opt, "target/association7");
+        makeDocAndTest(assoc, "target/association7");
     }
 
 
@@ -1457,14 +1243,7 @@ public class RoundTripFromJavaTest extends TestCase {
         assoc.setPlan(pFactory.newEntityRef(q("plan1")));
         assoc.getRole().add("someRole");
         assoc.getRole().add("someOtherRole");
-        
-        Agent ag1=pFactory.newAgent(q("ag1"));
-        Activity a1=pFactory.newActivity(q("a1"));
-        Entity plan1=pFactory.newEntity(q("plan1"));
-        pFactory.addType(plan1, pFactory.newQName("prov:Plan"));
-        Statement [] opt = new Statement[] { ag1, a1, plan1 };
-        
-        makeDocAndTest(assoc, opt, "target/association8");
+        makeDocAndTest(assoc, "target/association8");
     }
     
 
@@ -1477,14 +1256,7 @@ public class RoundTripFromJavaTest extends TestCase {
         addLabels(assoc);
         addTypes(assoc);
         addFurtherAttributes(assoc);
-        
-        Agent ag1=pFactory.newAgent(q("ag1"));
-        Activity a1=pFactory.newActivity(q("a1"));
-        Entity plan1=pFactory.newEntity(q("plan1"));
-        pFactory.addType(plan1, pFactory.newQName("prov:Plan"));
-        Statement [] opt = new Statement[] { ag1, a1, plan1 };
-        
-        makeDocAndTest(assoc, opt, "target/association9");
+        makeDocAndTest(assoc, "target/association9");
     }
 
  // ////////////////////////////////
@@ -1494,9 +1266,7 @@ public class RoundTripFromJavaTest extends TestCase {
         WasAttributedTo attr = pFactory.newWasAttributedTo(q("attr1"), 
                                                            pFactory.newEntityRef(q("e1")),
                                                            null);
-        Entity e1=pFactory.newEntity(q("e1"));
-    	Statement [] opt=new Statement[] { e1 };
-        makeDocAndTest(attr, opt, "target/attribution1");
+        makeDocAndTest(attr, "target/attribution1");
     }
     
     public void testAttribution2() throws JAXBException {
@@ -1504,9 +1274,7 @@ public class RoundTripFromJavaTest extends TestCase {
         WasAttributedTo attr = pFactory.newWasAttributedTo(q("attr2"), 
                                                            null,
                                                            pFactory.newAgentRef(q("ag1")));
-        Agent ag1=pFactory.newAgent(q("ag1"));
-        Statement [] opt = new Statement[] { ag1 };
-        makeDocAndTest(attr, opt, "target/attribution2");
+        makeDocAndTest(attr, "target/attribution2");
     }
     
     public void testAttribution3() throws JAXBException {
@@ -1514,10 +1282,7 @@ public class RoundTripFromJavaTest extends TestCase {
         WasAttributedTo attr = pFactory.newWasAttributedTo(q("attr3"), 
                                                            pFactory.newEntityRef(q("e1")),
                                                            pFactory.newAgentRef(q("ag1")));
-        Agent ag1=pFactory.newAgent(q("ag1"));
-        Entity e1=pFactory.newEntity(q("e1"));
-        Statement [] opt = new Statement[] { ag1, e1 };
-        makeDocAndTest(attr, opt, "target/attribution3");
+        makeDocAndTest(attr, "target/attribution3");
     }
 
 
@@ -1526,10 +1291,7 @@ public class RoundTripFromJavaTest extends TestCase {
         WasAttributedTo attr = pFactory.newWasAttributedTo(q("attr4"), 
                                                            pFactory.newEntityRef(q("e1")),
                                                            pFactory.newAgentRef(q("ag1")));
-        Agent ag1=pFactory.newAgent(q("ag1"));
-        Entity e1=pFactory.newEntity(q("e1"));
-        Statement [] opt = new Statement[] { ag1, e1 };
-        makeDocAndTest(attr, opt, "target/attribution4");
+        makeDocAndTest(attr, "target/attribution4");
     }
 
     
@@ -1538,10 +1300,7 @@ public class RoundTripFromJavaTest extends TestCase {
         WasAttributedTo attr = pFactory.newWasAttributedTo((QName)null, 
                                                            pFactory.newEntityRef(q("e1")),
                                                            pFactory.newAgentRef(q("ag1")));
-        Agent ag1=pFactory.newAgent(q("ag1"));
-        Entity e1=pFactory.newEntity(q("e1"));
-        Statement [] opt = new Statement[] { ag1, e1 };
-        makeDocAndTest(attr, opt, "target/attribution5");
+        makeDocAndTest(attr, "target/attribution5");
     }
     
     
@@ -1552,10 +1311,7 @@ public class RoundTripFromJavaTest extends TestCase {
                                                            pFactory.newEntityRef(q("e1")),
                                                            pFactory.newAgentRef(q("ag1")));
         addLabels(attr);
-        Agent ag1=pFactory.newAgent(q("ag1"));
-        Entity e1=pFactory.newEntity(q("e1"));
-        Statement [] opt = new Statement[] { ag1, e1 };
-        makeDocAndTest(attr, opt, "target/attribution6");
+        makeDocAndTest(attr, "target/attribution6");
     }
 
     public void testAttribution7() throws JAXBException {
@@ -1565,10 +1321,7 @@ public class RoundTripFromJavaTest extends TestCase {
                                                            pFactory.newAgentRef(q("ag1")));
         addLabels(attr);
         addTypes(attr);
-        Agent ag1=pFactory.newAgent(q("ag1"));
-        Entity e1=pFactory.newEntity(q("e1"));
-        Statement [] opt = new Statement[] { ag1, e1 };
-        makeDocAndTest(attr, opt, "target/attribution7");
+        makeDocAndTest(attr, "target/attribution7");
     }
 
 
@@ -1580,10 +1333,7 @@ public class RoundTripFromJavaTest extends TestCase {
         addLabels(attr);
         addTypes(attr);
         addFurtherAttributes(attr);
-        Agent ag1=pFactory.newAgent(q("ag1"));
-        Entity e1=pFactory.newEntity(q("e1"));
-        Statement [] opt = new Statement[] { ag1, e1 };
-        makeDocAndTest(attr, opt, "target/attribution8");
+        makeDocAndTest(attr, "target/attribution8");
     }
 
 
@@ -1595,9 +1345,7 @@ public class RoundTripFromJavaTest extends TestCase {
                                                               pFactory.newAgentRef(q("e1")),
                                                               null,
                                                               null);
-           Agent e1=pFactory.newAgent(q("e1"));
-       	Statement [] opt=new Statement[] { e1 };
-           makeDocAndTest(del, opt, "target/delegation1");
+           makeDocAndTest(del, "target/delegation1");
        }
        
        public void testDelegation2() throws JAXBException {
@@ -1606,9 +1354,7 @@ public class RoundTripFromJavaTest extends TestCase {
                                                               null,
                                                               pFactory.newAgentRef(q("ag1")),
                                                               null);
-           Agent ag1=pFactory.newAgent(q("ag1"));
-           Statement [] opt = new Statement[] { ag1 };
-           makeDocAndTest(del, opt, "target/delegation2");
+           makeDocAndTest(del, "target/delegation2");
        }
        
        public void testDelegation3() throws JAXBException {
@@ -1617,10 +1363,7 @@ public class RoundTripFromJavaTest extends TestCase {
                                                               pFactory.newAgentRef(q("e1")),
                                                               pFactory.newAgentRef(q("ag1")),
                                                               null);
-           Agent ag1=pFactory.newAgent(q("ag1"));
-           Agent e1=pFactory.newAgent(q("e1"));
-           Statement [] opt = new Statement[] { ag1, e1 };
-           makeDocAndTest(del, opt, "target/delegation3");
+           makeDocAndTest(del, "target/delegation3");
        }
 
 
@@ -1630,12 +1373,8 @@ public class RoundTripFromJavaTest extends TestCase {
                                                               pFactory.newAgentRef(q("e1")),
                                                               pFactory.newAgentRef(q("ag1")),
                                                               pFactory.newActivityRef(q("a")));
-           Agent ag1=pFactory.newAgent(q("ag1"));
-           Agent e1=pFactory.newAgent(q("e1"));
-           Activity a=pFactory.newActivity(q("a"));
-           Statement [] opt = new Statement[] { ag1, e1, a };
            
-           makeDocAndTest(del, opt, "target/delegation4");
+           makeDocAndTest(del, "target/delegation4");
        }
 
        
@@ -1645,10 +1384,7 @@ public class RoundTripFromJavaTest extends TestCase {
                                                               pFactory.newAgentRef(q("e1")),
                                                               pFactory.newAgentRef(q("ag1")),
                                                               null);
-           Agent ag1=pFactory.newAgent(q("ag1"));
-           Agent e1=pFactory.newAgent(q("e1"));
-           Statement [] opt = new Statement[] { ag1, e1 };
-           makeDocAndTest(del, opt, "target/delegation5");
+           makeDocAndTest(del, "target/delegation5");
        }
        
        
@@ -1660,11 +1396,7 @@ public class RoundTripFromJavaTest extends TestCase {
                                                               pFactory.newAgentRef(q("ag1")),
                                                               pFactory.newActivityRef(q("a")));
            addLabels(del);
-           Agent ag1=pFactory.newAgent(q("ag1"));
-           Agent e1=pFactory.newAgent(q("e1"));
-           Activity a=pFactory.newActivity(q("a"));
-           Statement [] opt = new Statement[] { ag1, e1, a };
-           makeDocAndTest(del, opt, "target/delegation6");
+           makeDocAndTest(del, "target/delegation6");
        }
 
        public void testDelegation7() throws JAXBException {
@@ -1675,11 +1407,7 @@ public class RoundTripFromJavaTest extends TestCase {
                                                               pFactory.newActivityRef(q("a")));
            addLabels(del);
            addTypes(del);
-           Agent ag1=pFactory.newAgent(q("ag1"));
-           Agent e1=pFactory.newAgent(q("e1"));
-           Activity a=pFactory.newActivity(q("a"));
-           Statement [] opt = new Statement[] { ag1, e1, a };
-           makeDocAndTest(del, opt, "target/delegation7");
+           makeDocAndTest(del, "target/delegation7");
        }
 
 
@@ -1692,11 +1420,7 @@ public class RoundTripFromJavaTest extends TestCase {
            addLabels(del);
            addTypes(del);
            addFurtherAttributes(del);
-           Agent ag1=pFactory.newAgent(q("ag1"));
-           Agent e1=pFactory.newAgent(q("e1"));
-           Activity a=pFactory.newActivity(q("a"));
-           Statement [] opt = new Statement[] { ag1, e1, a };
-           makeDocAndTest(del, opt, "target/delegation8");
+           makeDocAndTest(del, "target/delegation8");
        }
 
        // ////////////////////////////////
@@ -1706,9 +1430,7 @@ public class RoundTripFromJavaTest extends TestCase {
            WasInformedBy inf = pFactory.newWasInformedBy(q("inf1"), 
                                                          pFactory.newActivityRef(q("a2")),
                                                          null);
-           Activity a2=pFactory.newActivity(q("a2"));
-          	Statement [] opt=new Statement[] { a2 };
-           makeDocAndTest(inf, opt, "target/communication1");
+           makeDocAndTest(inf, "target/communication1");
        }
        
        public void testCommunication2() throws JAXBException {
@@ -1716,9 +1438,7 @@ public class RoundTripFromJavaTest extends TestCase {
            WasInformedBy inf = pFactory.newWasInformedBy(q("inf2"), 
                                                               null,
                                                               pFactory.newActivityRef(q("a1")));
-           Activity a1=pFactory.newActivity(q("a1"));
-          	Statement [] opt=new Statement[] { a1 };
-           makeDocAndTest(inf, opt, "target/communication2");
+           makeDocAndTest(inf, "target/communication2");
        }
        
        public void testCommunication3() throws JAXBException {
@@ -1726,10 +1446,7 @@ public class RoundTripFromJavaTest extends TestCase {
            WasInformedBy inf = pFactory.newWasInformedBy(q("inf3"), 
                                                          pFactory.newActivityRef(q("a2")),
                                                          pFactory.newActivityRef(q("a1")));
-           Activity a1=pFactory.newActivity(q("a1"));
-           Activity a2=pFactory.newActivity(q("a2"));
-          	Statement [] opt=new Statement[] { a1, a2 };
-           makeDocAndTest(inf, opt, "target/communication3");
+           makeDocAndTest(inf, "target/communication3");
        }
 
 
@@ -1739,10 +1456,7 @@ public class RoundTripFromJavaTest extends TestCase {
            WasInformedBy inf = pFactory.newWasInformedBy((QName)null, 
                                                          pFactory.newActivityRef(q("a2")),
                                                          pFactory.newActivityRef(q("a1")));
-           Activity a1=pFactory.newActivity(q("a1"));
-           Activity a2=pFactory.newActivity(q("a2"));
-          	Statement [] opt=new Statement[] { a1, a2 };
-           makeDocAndTest(inf, opt, "target/communication4");
+           makeDocAndTest(inf, "target/communication4");
        }
        
        
@@ -1753,10 +1467,7 @@ public class RoundTripFromJavaTest extends TestCase {
                                                          pFactory.newActivityRef(q("a2")),
                                                          pFactory.newActivityRef(q("a1")));
            addLabels(inf);
-           Activity a1=pFactory.newActivity(q("a1"));
-           Activity a2=pFactory.newActivity(q("a2"));
-          	Statement [] opt=new Statement[] { a1, a2 };
-           makeDocAndTest(inf, opt, "target/communication5");
+           makeDocAndTest(inf, "target/communication5");
        }
 
        public void testCommunication6() throws JAXBException {
@@ -1766,10 +1477,7 @@ public class RoundTripFromJavaTest extends TestCase {
                                                          pFactory.newActivityRef(q("a1")));
            addLabels(inf);
            addTypes(inf);
-           Activity a1=pFactory.newActivity(q("a1"));
-           Activity a2=pFactory.newActivity(q("a2"));
-          	Statement [] opt=new Statement[] { a1, a2 };
-           makeDocAndTest(inf, opt, "target/communication6");
+           makeDocAndTest(inf, "target/communication6");
        }
 
 
@@ -1781,10 +1489,7 @@ public class RoundTripFromJavaTest extends TestCase {
            addLabels(inf);
            addTypes(inf);
            addFurtherAttributes(inf);
-           Activity a1=pFactory.newActivity(q("a1"));
-           Activity a2=pFactory.newActivity(q("a2"));
-          	Statement [] opt=new Statement[] { a1, a2 };
-           makeDocAndTest(inf, opt, "target/communication7");
+           makeDocAndTest(inf, "target/communication7");
        }
 
 
@@ -1795,9 +1500,7 @@ public class RoundTripFromJavaTest extends TestCase {
            WasInfluencedBy inf = pFactory.newWasInfluencedBy(q("inf1"), 
                                                              pFactory.newAnyRef(q("a2")),
                                                              null);
-           Activity a2=pFactory.newActivity(q("a2"));
-         	Statement [] opt=new Statement[] { a2 };
-           makeDocAndTest(inf, opt, "target/influence1");
+           makeDocAndTest(inf, "target/influence1");
        }
        
        public void testInfluence2() throws JAXBException {
@@ -1805,9 +1508,7 @@ public class RoundTripFromJavaTest extends TestCase {
            WasInfluencedBy inf = pFactory.newWasInfluencedBy(q("inf2"), 
                                                              null,
                                                              pFactory.newAnyRef(q("a1")));
-           Activity a1=pFactory.newActivity(q("a1"));
-          	Statement [] opt=new Statement[] { a1 };
-           makeDocAndTest(inf, opt, "target/influence2");
+           makeDocAndTest(inf, "target/influence2");
        }
        
        public void testInfluence3() throws JAXBException {
@@ -1815,10 +1516,7 @@ public class RoundTripFromJavaTest extends TestCase {
            WasInfluencedBy inf = pFactory.newWasInfluencedBy(q("inf3"), 
                                                              pFactory.newAnyRef(q("a2")),
                                                              pFactory.newAnyRef(q("a1")));
-           Activity a1=pFactory.newActivity(q("a1"));
-           Activity a2=pFactory.newActivity(q("a2"));
-          	Statement [] opt=new Statement[] { a1, a2 };
-           makeDocAndTest(inf, opt, "target/influence3");
+           makeDocAndTest(inf, "target/influence3");
        }
 
 
@@ -1828,10 +1526,7 @@ public class RoundTripFromJavaTest extends TestCase {
            WasInfluencedBy inf = pFactory.newWasInfluencedBy((QName)null, 
                                                              pFactory.newAnyRef(q("a2")),
                                                              pFactory.newAnyRef(q("a1")));
-           Activity a1=pFactory.newActivity(q("a1"));
-           Activity a2=pFactory.newActivity(q("a2"));
-          	Statement [] opt=new Statement[] { a1, a2 };
-           makeDocAndTest(inf, opt, "target/influence4");
+           makeDocAndTest(inf, "target/influence4");
        }
        
        
@@ -1842,10 +1537,7 @@ public class RoundTripFromJavaTest extends TestCase {
                                                              pFactory.newAnyRef(q("a2")),
                                                              pFactory.newAnyRef(q("a1")));
            addLabels(inf);
-           Activity a1=pFactory.newActivity(q("a1"));
-           Activity a2=pFactory.newActivity(q("a2"));
-          	Statement [] opt=new Statement[] { a1, a2 };
-           makeDocAndTest(inf, opt, "target/influence5");
+           makeDocAndTest(inf, "target/influence5");
        }
 
        public void testInfluence6() throws JAXBException {
@@ -1855,10 +1547,7 @@ public class RoundTripFromJavaTest extends TestCase {
                                                              pFactory.newAnyRef(q("a1")));
            addLabels(inf);
            addTypes(inf);
-           Activity a1=pFactory.newActivity(q("a1"));
-           Activity a2=pFactory.newActivity(q("a2"));
-          	Statement [] opt=new Statement[] { a1, a2 };
-           makeDocAndTest(inf, opt, "target/influence6");
+           makeDocAndTest(inf, "target/influence6");
        }
 
 
@@ -1870,10 +1559,7 @@ public class RoundTripFromJavaTest extends TestCase {
            addLabels(inf);
            addTypes(inf);
            addFurtherAttributes(inf);
-           Activity a1=pFactory.newActivity(q("a1"));
-           Activity a2=pFactory.newActivity(q("a2"));
-          	Statement [] opt=new Statement[] { a1, a2 };
-           makeDocAndTest(inf, opt, "target/influence7");
+           makeDocAndTest(inf, "target/influence7");
        }
 
        
@@ -1884,12 +1570,7 @@ public class RoundTripFromJavaTest extends TestCase {
 	setNamespaces();
            AlternateOf alt = pFactory.newAlternateOf(pFactory.newEntityRef(q("e2")),
                                                      pFactory.newEntityRef(q("e1")));
-           Entity e1=pFactory.newEntity(q("e1")); 
-           Entity e2=pFactory.newEntity(q("e2"));
-        	Statement [] opt=new Statement[] { e1, e2 };
-        	
-        	
-           makeDocAndTest(alt, opt, "target/alternate1");
+           makeDocAndTest(alt, "target/alternate1");
        }
        
 
@@ -1897,10 +1578,7 @@ public class RoundTripFromJavaTest extends TestCase {
 	setNamespaces();
            SpecializationOf spe = pFactory.newSpecializationOf(pFactory.newEntityRef(q("e2")),
                                                                pFactory.newEntityRef(q("e1")));
-           Entity e1=pFactory.newEntity(q("e1")); 
-           Entity e2=pFactory.newEntity(q("e2"));
-        	Statement [] opt=new Statement[] { e1, e2 };
-           makeDocAndTest(spe, opt, "target/specialization1");
+           makeDocAndTest(spe, "target/specialization1");
        }
        
        
@@ -1909,10 +1587,7 @@ public class RoundTripFromJavaTest extends TestCase {
            MentionOf men = pFactory.newMentionOf(pFactory.newEntityRef(q("e2")),
                                                  pFactory.newEntityRef(q("e1")),
                                                  null);
-           Entity e1=pFactory.newEntity(q("e1")); 
-           Entity e2=pFactory.newEntity(q("e2"));
-        	Statement [] opt=new Statement[] { e1, e2 };
-           makeDocAndTest(men, opt, "target/mention1");
+           makeDocAndTest(men, "target/mention1");
        }
        
        public void testMention2() throws JAXBException {
@@ -1920,12 +1595,7 @@ public class RoundTripFromJavaTest extends TestCase {
            MentionOf men = pFactory.newMentionOf(pFactory.newEntityRef(q("e2")),
                                                  pFactory.newEntityRef(q("e1")),
                                                  pFactory.newEntityRef(q("b")));
-           Entity e1=pFactory.newEntity(q("e1")); 
-           Entity e2=pFactory.newEntity(q("e2"));
-           Entity b=pFactory.newEntity(q("b"));
-           pFactory.addType(b, pFactory.newQName("prov:Bundle"));
-        	Statement [] opt=new Statement[] { e1, e2, b };
-           makeDocAndTest(men, opt, "target/mention2");
+           makeDocAndTest(men, "target/mention2");
        }
        
 
@@ -1933,12 +1603,7 @@ public class RoundTripFromJavaTest extends TestCase {
 	setNamespaces();
            HadMember mem = pFactory.newHadMember(pFactory.newEntityRef(q("c")),
                                                  pFactory.newEntityRef(q("e1")));
-           Entity c=pFactory.newEntity(q("c")); 
-           pFactory.addType(c, pFactory.newQName("prov:Collection"));
-
-           Entity e1=pFactory.newEntity(q("e1"));
-       	   Statement [] opt=new Statement[] { c, e1 };
-           makeDocAndTest(mem, opt, "target/member1");
+           makeDocAndTest(mem, "target/member1");
        }
        public void testMembership2() throws JAXBException {
 	setNamespaces();
@@ -1946,11 +1611,7 @@ public class RoundTripFromJavaTest extends TestCase {
                                                  pFactory.newEntityRef(q("e1")),
                                                  pFactory.newEntityRef(q("e2")));
            //TODO: multiple arguments not supported by toolbox 
-           Entity c=pFactory.newEntity(q("c")); 
-           Entity e1=pFactory.newEntity(q("e1"));
-           Entity e2=pFactory.newEntity(q("e2"));
-       	   Statement [] opt=new Statement[] { c, e1, e2 };
-           makeDocAndTest(mem, opt, "target/member2");
+           makeDocAndTest(mem, "target/member2");
        }
        public void testMembership3() throws JAXBException {
 	setNamespaces();
@@ -1959,12 +1620,7 @@ public class RoundTripFromJavaTest extends TestCase {
                                                  pFactory.newEntityRef(q("e2")),
                                                  pFactory.newEntityRef(q("e3")));
            //TODO: multiple arguments not supported by toolbox 
-           Entity c=pFactory.newEntity(q("c")); 
-           Entity e1=pFactory.newEntity(q("e1"));
-           Entity e2=pFactory.newEntity(q("e2"));
-           Entity e3=pFactory.newEntity(q("e3"));
-       	   Statement [] opt=new Statement[] { c, e1, e2, e3 };
-           makeDocAndTest(mem, opt, "target/member3");
+           makeDocAndTest(mem, "target/member3");
        }
      
        public void testScruffyGeneration1() throws JAXBException  {


### PR DESCRIPTION
I've added a getImplicitTypes function, which uses the domains table (currently) in Ontology to determine the type of a resource. The properties are then applied, and the creation of the bean is omitted in implicit cases.

This removes the need for optional statements in the Java tests. I've re-added the tests that were previously skipped in checkTest.

Some things to do:
- Use the range table for cases where the object can be used to work out the type.
- Fix mentionOf (this is trickier, due to its two-predicate nature). 
- Influence/Collection still need to be handled correctly.
