### PR TITLE
BNode handling

### DIFF
--- a/prov-rdf/src/test/java/org/openprovenance/prov/rdf/RoundTripFromRdfTest.java
+++ b/prov-rdf/src/test/java/org/openprovenance/prov/rdf/RoundTripFromRdfTest.java
@@ -25,12 +25,9 @@ public class RoundTripFromRdfTest extends TestCase {
 	private String folder;
 	private static String[] folders = { "issues", "examples" };
 	private static List<String> skip = Arrays
-			.asList(new String[] { "prov-o-property-hadUsage-FAIL.ttl",
-					"prov-o-property-hadGeneration-FAIL.ttl",
-					"prov-o-property-hadMember-PASS.ttl",
-					"prov-o-property-alternateOf-PASS.ttl",
-					"prov-o-property-specializationOf-PASS.ttl",
-					"ex_alternateOf.ttl" });
+			.asList(new String[] { 
+					"prov-o-property-hadUsage-FAIL.ttl",
+					"prov-o-property-hadGeneration-FAIL.ttl" });
 
 	public RoundTripFromRdfTest(String folder, String file)
 	{


### PR DESCRIPTION
Whenever I encounter a BNode, I convert it into a QName with our prov toolbox namespace. There are then a couple of checks:
- When creating an influence, if the ID is a BNode and is not referenced by any other triples, it is nullified.
- Once all parsing is done, it goes through all the objects. If they have a BNode ID, it nullifies the ID if the BNode is not referenced by any other triples.
