### PR TITLE
Don't hardcode /tmp (which don't exist on Windows)

### DIFF
--- a/prov-interop/src/main/java/org/openprovenance/prov/interop/InteropFramework.java
+++ b/prov-interop/src/main/java/org/openprovenance/prov/interop/InteropFramework.java
@@ -234,7 +234,7 @@ public class InteropFramework
 	    }
 	    case PDF: {
 		String configFile=null; // TODO: get it as option
-		File tmp=File.createTempFile("viz-", ".dot",new File("/tmp"));
+		File tmp=File.createTempFile("viz-", ".dot");
 	                
 		String dotFileOut=tmp.getAbsolutePath(); //give it as option, if not available create tmp file
 		ProvToDot toDot=
@@ -252,7 +252,7 @@ public class InteropFramework
 	    case JPEG:
 	    case SVG:{
                 String configFile=null; // give it as option
-                File tmp=File.createTempFile("viz-", ".dot",new File("/tmp"));
+                File tmp=File.createTempFile("viz-", ".dot");
                 
                 String dotFileOut=tmp.getAbsolutePath(); //give it as option, if not available create tmp file
                 //ProvToDot toDot=new ProvToDot((configFile==null)? "../../ProvToolbox/prov-dot/src/main/resources/defaultConfigWithRoleNoLabel.xml" : configFile); 


### PR DESCRIPTION
File.createTempFile() will do the right thing anyway
