### PR TITLE
Update Attribute.java to make AttributeKind enum public.

### DIFF
--- a/prov-xml/src/main/java/org/openprovenance/prov/xml/Attribute.java
+++ b/prov-xml/src/main/java/org/openprovenance/prov/xml/Attribute.java
@@ -18,7 +18,7 @@ public class Attribute {
     public static QName PROV_LOCATION_QNAME=provQName("location");
     public static QName PROV_VALUE_QNAME=provQName("value");
     
-    enum AttributeKind {
+    public enum AttributeKind {
 	PROV_TYPE,
 	PROV_LABEL,
 	PROV_ROLE,


### PR DESCRIPTION
There are public methods that take Attribute Kind as an argument. Attribute Kind enum should be declared public so that it is visible outside of Attribute.
