### PR TITLE
Changed how prov.model.Type is presented

### DIFF
--- a/prov-dot/src/main/java/org/openprovenance/prov/dot/ProvToDot.java
+++ b/prov-dot/src/main/java/org/openprovenance/prov/dot/ProvToDot.java
@@ -537,7 +537,7 @@ public class ProvToDot {
     public HashMap<String,String> addAnnotationLabel(HasExtensibility ann, HashMap<String,String> properties) {
         String label="";
         label=label+"<<TABLE cellpadding=\"0\" border=\"0\">\n";
-        for (Object type: ((HasType)ann).getType()) {
+        for (Type type: ((HasType)ann).getType()) {
             label=label+"	<TR>\n";
             label=label+"	    <TD align=\"left\">" + "type" + ":</TD>\n";
             label=label+"	    <TD align=\"left\">" + getPropertyValueFromAny(type) + "</TD>\n";
@@ -595,13 +595,21 @@ public class ProvToDot {
         }*/
     }
 
-    public String getPropertyValueFromAny (Object val) {
-        if (val instanceof QName) {
+    public String getPropertyValueFromAny (Type t) {
+    	if(t.getValue() instanceof QName) {
+    		QName tt=((QName)t.getValue());
+    		return tt.getNamespaceURI()+tt.getLocalPart();
+    	}
+    	else {
+    		Object tt=t.getValue();
+    		return tt.toString();
+    	}
+        /*if (val instanceof QName) {
             QName q=(QName)val;
             return q.getNamespaceURI() + q.getLocalPart();
         } else {
                 return "" +  val;
-        }
+        }*/
     }
     public String getPropertyValueFromAny (Attribute o) {
         Object val=o.getValue();


### PR DESCRIPTION
Changed how org.openprovenance.prov.model.Type of org.openprovenance.prov.model.HasType is presented. Change to methods: addAnnotationLabel and getPropertyValueFromAny. Method getType returns Type not Object (line 540). And changed method getPropertyValueFromAny signature to accept Type instead of Object (line 598).
