### PR TITLE
Changed: Namespace resolution in a bundle to inherit the default namespace of the document if available

### DIFF
--- a/prov-json/src/main/java/org/openprovenance/prov/json/Converter.java
+++ b/prov-json/src/main/java/org/openprovenance/prov/json/Converter.java
@@ -34,6 +34,7 @@ public class Converter {
 
     }
     
+	@SuppressWarnings("unchecked")
 	public Document readDocument(String file) throws JsonSyntaxException, JsonIOException, FileNotFoundException {
 	    Document doc = (Document) gson.fromJson(new BufferedReader(new FileReader(file)), class1);
 	    return doc;
@@ -43,6 +44,15 @@ public class Converter {
 	    BufferedWriter writer = new BufferedWriter(new FileWriter(file));
 	    gson.toJson(doc, writer);
 	    writer.close();
+	}
+	
+	public String getString(Document doc) {
+	    return gson.toJson(doc);
+	}
+	
+	@SuppressWarnings("unchecked")
+	public Document fromString(String jsonStr) {
+	    return (Document) gson.fromJson(jsonStr, class1);
 	}
 
 }

--- a/prov-json/src/main/java/org/openprovenance/prov/json/ProvDocumentSerializer.java
+++ b/prov-json/src/main/java/org/openprovenance/prov/json/ProvDocumentSerializer.java
@@ -23,13 +23,7 @@ public class ProvDocumentSerializer implements JsonSerializer<Document> {
     public JsonElement serialize(final Document doc, 
                                  Type typeOfSrc,
 				 JsonSerializationContext context) {
-	QualifiedNameExport qExport = new QualifiedNameExport() {
-	    @Override
-	    public String qualifiedNameToString(QualifiedName qname) {
-		return doc.getNamespace().qualifiedNameToString(qname);
-	    }
-	};
-	JSONConstructor jsonConstructor = new JSONConstructor(qExport, pFactory.getName());
+	JSONConstructor jsonConstructor = new JSONConstructor(pFactory.getName());
 	BeanTraversal bt = new BeanTraversal(jsonConstructor, 
 	                                     pFactory);
 	bt.convert(doc);

--- a/prov-model/src/main/java/org/openprovenance/prov/model/Name.java
+++ b/prov-model/src/main/java/org/openprovenance/prov/model/Name.java
@@ -9,7 +9,7 @@ public class Name {
     public Name(ProvFactory pFactory) {
 	this.pFactory=pFactory;
 	PROV_LANG_STRING = newProvQualifiedName("InternationalizedString");
-	
+	PROV_QUALIFIED_NAME = newProvQualifiedName("QualifiedName");
 	PROV_REVISION = newProvQualifiedName("Revision");
 	PROV_QUOTATION = newProvQualifiedName("Quotation");
 	PROV_PRIMARY_SOURCE = newProvQualifiedName("PrimarySource");
@@ -114,6 +114,7 @@ public class Name {
     
     
     final public QualifiedName PROV_LANG_STRING ;
+    final public QualifiedName PROV_QUALIFIED_NAME ;
     final public QualifiedName PROV_REVISION ;
     final public QualifiedName PROV_QUOTATION ;
     final public QualifiedName PROV_PRIMARY_SOURCE ;

--- a/prov-model/src/main/java/org/openprovenance/prov/model/Namespace.java
+++ b/prov-model/src/main/java/org/openprovenance/prov/model/Namespace.java
@@ -264,11 +264,12 @@ public class Namespace implements QualifiedNameExport {
  		return pref + ":" + name.getLocalPart();
  	    } else {
  		if (parent!=null) {
- 		    parent.qualifiedNameToString(name,this);
+ 		    return parent.qualifiedNameToString(name,this);
  		}
- 		throw new QualifiedNameException("unknown qualified name " + name 
- 		                                 + " with namespace " + toString()
- 		                                 + ((child==null)? "" : (" and " + child)));
+ 		else 
+ 		    throw new QualifiedNameException("unknown qualified name " + name 
+ 		                                     + " with namespace " + toString()
+ 		                                     + ((child==null)? "" : (" and " + child)));
  	    }
  	}
      }

--- a/prov-xml/src/test/java/org/openprovenance/prov/xml/DocumentEquality.java
+++ b/prov-xml/src/test/java/org/openprovenance/prov/xml/DocumentEquality.java
@@ -49,17 +49,15 @@ public class DocumentEquality {
 	private boolean statementEqual(StatementOrBundle r1,
 			StatementOrBundle r2) {
 		// If one of the statemens is a named bundle
-		if (r1 instanceof NamedBundle || r2 instanceof NamedBundle) {
-			if (r1 instanceof NamedBundle && r2 instanceof NamedBundle) {
-				NamedBundle b1 = (NamedBundle) r1;
-				NamedBundle b2 = (NamedBundle) r2;
-				if (!b1.getId().equals(b2.getId()))
-					return false;
-				List<?> stmts1 = b1.getStatement();
-				List<?> stmts2 = b2.getStatement();
-				return statementListEqual((List<StatementOrBundle>) stmts1,
-						(List<StatementOrBundle>) stmts2);
-			}
+		if (r1 instanceof NamedBundle && r2 instanceof NamedBundle) {
+			NamedBundle b1 = (NamedBundle) r1;
+			NamedBundle b2 = (NamedBundle) r2;
+			if (!b1.getId().equals(b2.getId()))
+				return false;
+			List<?> stmts1 = b1.getStatement();
+			List<?> stmts2 = b2.getStatement();
+			return statementListEqual((List<StatementOrBundle>) stmts1,
+			                          (List<StatementOrBundle>) stmts2);
 		}
 		// Two normal statements
 		Class<?> class1 = r1.getClass();


### PR DESCRIPTION
The method `Namespace.stringToQualifiedName` will now try to resolve the given string with the parent Namespace if there is one and it fails to resolve the string on its own.
