### PR TITLE
Support specifying formats explicity. Support standard i/o.

### DIFF
--- a/prov-interop/src/main/java/org/openprovenance/prov/interop/CommandLineArguments.java
+++ b/prov-interop/src/main/java/org/openprovenance/prov/interop/CommandLineArguments.java
@@ -27,6 +27,9 @@ public class CommandLineArguments {
     public static final String FLATTEN = "flatten";
     private static final String GENORDER = "genorder";
     public static final String FORMATS = "formats";
+    public static final String INFORMAT = "informat";
+    public static final String OUTFORMAT = "outformat";
+    public static final String BINDFORMAT = "bindformat";
 
     // see http://commons.apache.org/cli/usage.html
     static Options buildOptions() {
@@ -90,6 +93,25 @@ public class CommandLineArguments {
         
         Option formats = new Option(FORMATS, "list supported formats");
 
+        Option informat = OptionBuilder
+                .withArgName("string")
+                .hasArg()
+                .withDescription("specify the format of the input")
+                .create(INFORMAT);
+
+        Option outformat = OptionBuilder
+                .withArgName("string")
+                .hasArg()
+                .withDescription("specify the format of the output")
+                .create(OUTFORMAT);
+
+        Option bindformat = OptionBuilder
+                .withArgName("string")
+                .hasArg()
+                .withDescription("specify the format of the bindings")
+                .create(BINDFORMAT);
+
+
         Options options = new Options();
 
         options.addOption(help);
@@ -108,6 +130,9 @@ public class CommandLineArguments {
         options.addOption(generator);
         options.addOption(genorder);
         options.addOption(formats);
+        options.addOption(informat);
+        options.addOption(outformat);
+        options.addOption(bindformat);
 
         return options;
 
@@ -122,11 +147,14 @@ public class CommandLineArguments {
         String debug = null;
         String logfile = null;
         String infile = null;
+        String informat = null;
         String outfile = null;
+        String outformat = null;
         String namespaces = null;
         String title = null;
         String layout = null;
         String bindings = null;
+        String bindingformat = null;
         String generator = null;
         String index=null;
         String flatten=null;
@@ -147,11 +175,14 @@ public class CommandLineArguments {
 	    if (line.hasOption(FLATTEN))    flatten    = FLATTEN;
 	    if (line.hasOption(LOGFILE))    logfile    = line.getOptionValue(LOGFILE);
             if (line.hasOption(INFILE))     infile     = line.getOptionValue(INFILE);
+            if (line.hasOption(INFORMAT))   informat = line.getOptionValue(INFORMAT);
 	    if (line.hasOption(OUTFILE))    outfile    = line.getOptionValue(OUTFILE);
+            if (line.hasOption(OUTFORMAT)) outformat = line.getOptionValue(OUTFORMAT);
             if (line.hasOption(NAMESPACES)) namespaces = line.getOptionValue(NAMESPACES);
             if (line.hasOption(TITLE))      title = line.getOptionValue(TITLE);
             if (line.hasOption(LAYOUT))      layout = line.getOptionValue(LAYOUT);
             if (line.hasOption(BINDINGS))   bindings = line.getOptionValue(BINDINGS);
+            if (line.hasOption(BINDFORMAT)) bindingformat = line.getOptionValue(BINDFORMAT);
             if (line.hasOption(GENERATOR))  generator = line.getOptionValue(GENERATOR);
             if (line.hasOption(GENORDER))   addOrderp=true;
             if (line.hasOption(FORMATS))      listFormatsp = true;
@@ -173,11 +204,14 @@ public class CommandLineArguments {
                                                           debug,
                                                           logfile,
                                                           infile,
+                                                          informat,
                                                           outfile,
+                                                          outformat,
                                                           namespaces,
                                                           title,
                                                           layout,
                                                           bindings,
+                                                          bindingformat,
                                                           addOrderp,
                                                           generator,
                                                           index,

--- a/prov-interop/src/main/java/org/openprovenance/prov/interop/InteropFramework.java
+++ b/prov-interop/src/main/java/org/openprovenance/prov/interop/InteropFramework.java
@@ -110,7 +110,7 @@ public class InteropFramework implements InteropMediaType {
     }
 
     /* backwards compatibility with pre-format version*/
-    public InteropFramework(String verbose, String debug, String logfile,
+    @Deprecated public InteropFramework(String verbose, String debug, String logfile,
             String infile, String outfile, String namespaces, String title,
             String layout, String bindings, boolean addOrderp, String generator,
             String index, String flatten, ProvFactory pFactory) {

--- a/prov-template/src/main/java/org/openprovenance/prov/template/Expand.java
+++ b/prov-template/src/main/java/org/openprovenance/prov/template/Expand.java
@@ -64,7 +64,7 @@ public class Expand {
 	Bindings bindings1 = Bindings.fromDocument(docBindings,pf);
 
 	Groupings grp1 = Groupings.fromDocument(docIn);
-	System.out.println("expander: Found groupings " + grp1);
+	System.err.println("expander: Found groupings " + grp1);
 
 	Bundle bun1 = (Bundle) expand(bun, bindings1, grp1).get(0);
 	Document doc1 = pf.newDocument();

--- a/prov-template/src/test/java/org/openprovenance/prov/template/ExpandTest.java
+++ b/prov-template/src/test/java/org/openprovenance/prov/template/ExpandTest.java
@@ -37,7 +37,7 @@ public class ExpandTest extends TestCase {
     QualifiedName var_end=pf.newQualifiedName(VAR_NS, "end", "var");
 
     public  void expander(String in, String inBindings, String out) throws IOException, Throwable {
-	System.out.println("expander ==========================================> " + in);
+	System.err.println("expander ==========================================> " + in);
 	
 	Document doc= new Utility().readDocument(in, pf);
 	Document docBindings= new Utility().readDocument(inBindings,pf);
@@ -47,7 +47,7 @@ public class ExpandTest extends TestCase {
 
 	Groupings grp1=Groupings.fromDocument(doc);
 
-	System.out.println("Found groupings " + grp1);
+	System.err.println("Found groupings " + grp1);
 	
 	Bundle bun1=(Bundle) new Expand(pf,addOrderp).expand(bun, bindings1, grp1).get(0);
 	Document doc1=pf.newDocument();
@@ -63,7 +63,7 @@ public class ExpandTest extends TestCase {
 	//InteropFramework inf=new InteropFramework();
 	//inf.writeDocument(out, doc1);
 	
-	System.out.println("expander ==========================================> ");
+	System.err.println("expander ==========================================> ");
     }
     
     boolean addOrderp=true;
@@ -72,7 +72,7 @@ public class ExpandTest extends TestCase {
                           String out,
                           Bindings bindings1,
                           String outBindings) throws IOException, Throwable {
-	System.out.println("expander ==========================================> " + in);
+	System.err.println("expander ==========================================> " + in);
 	
 	Document doc= new Utility().readDocument(in, pf);
 	
@@ -80,7 +80,7 @@ public class ExpandTest extends TestCase {
 
 	Groupings grp1=Groupings.fromDocument(doc);
 
-	System.out.println("Found groupings " + grp1);
+	System.err.println("Found groupings " + grp1);
 	
 	Bundle bun1=(Bundle) new Expand(pf,addOrderp).expand(bun, bindings1, grp1).get(0);
 	Document doc1=pf.newDocument();
@@ -101,7 +101,7 @@ public class ExpandTest extends TestCase {
 	Namespace.withThreadNamespace(doc2.getNamespace());
 	new Utility().writeDocument(doc2,outBindings,pf);
 	
-	System.out.println("expander ==========================================> ");
+	System.err.println("expander ==========================================> ");
 
     }
 


### PR DESCRIPTION
To provconvert, I've added:
a) -informat -outformat -bindformat <format> where format is a supported file extension or mimetype
b) the use of - as an indicator to use standard input/output