### PR TITLE
Reverse order of relation of node to annotations

### DIFF
--- a/prov-dot/src/main/java/org/openprovenance/prov/dot/ProvToDot.java
+++ b/prov-dot/src/main/java/org/openprovenance/prov/dot/ProvToDot.java
@@ -415,8 +415,8 @@ public class ProvToDot {
                     addAnnotationShape(ann,addAnnotationColor(ann,addAnnotationLabel(ann,properties))),
                     out);
         HashMap<String,String> linkProperties=new HashMap<String, String>();
-        emitRelation(qualifiedNameToString(newId),
-                     qualifiedNameToString(((Identifiable)ann).getId()),
+        emitRelation(qualifiedNameToString(((Identifiable)ann).getId()),
+                     qualifiedNameToString(newId),
                      addAnnotationLinkProperties(ann,linkProperties),out,true);
     }
 


### PR DESCRIPTION
This generally makes for fewer line crossings in the generated graphviz diagrams.