### PR TITLE
simpler repo layout, flat lib/*.jar

### DIFF
--- a/modules-executable/toolbox/pom.xml
+++ b/modules-executable/toolbox/pom.xml
@@ -151,7 +151,7 @@
                         </program>
 
                     </programs>
-                    <repositoryLayout>default</repositoryLayout>
+                    <repositoryLayout>flat</repositoryLayout>
                     <repositoryName>repo</repositoryName>
                     <platforms>
                         <platform>windows</platform>


### PR DESCRIPTION
..avoiding Windows directory "path too long" issue (see also #153)

NOTE: This assumes no two JARs have the same name AND version.

