### PR TITLE
Bump ant from 1.10.9 to 1.10.11 in /modules-legacy/prov-sql

### DIFF
--- a/modules-legacy/prov-sql/pom.xml
+++ b/modules-legacy/prov-sql/pom.xml
@@ -221,7 +221,7 @@
                         <dependency>
                             <groupId>org.apache.ant</groupId>
                             <artifactId>ant</artifactId>
-                            <version>1.10.9</version>
+                            <version>1.10.11</version>
                         </dependency>
 
                         <dependency>


### PR DESCRIPTION
Bumps ant from 1.10.9 to 1.10.11.

---
updated-dependencies:
- dependency-name: org.apache.ant:ant
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>